### PR TITLE
Grunt git release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
                     replacements: [
                     // place files inline example
                         {
-                            pattern: '    <link rel="stylesheet" href="../../css/styles.min.css?{{ cacheBuster }}" media="all" />',
+                            pattern: '    <link rel="stylesheet" href="../../css/styles-<%= pkg.version %>.min.css?{{ cacheBuster }}" media="all" />',
                             replacement: '    <link rel="stylesheet" href="../../css/styles.css?{{ cacheBuster }}" media="all" />'
                         },
                         {
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
                     // place files inline example
                         {
                             pattern: '    <link rel="stylesheet" href="../../css/styles.css?{{ cacheBuster }}" media="all" />',
-                            replacement: '    <link rel="stylesheet" href="../../css/styles.min.css?{{ cacheBuster }}" media="all" />'
+                            replacement: '    <link rel="stylesheet" href="../../css/styles-<%= pkg.version %>.min.css?{{ cacheBuster }}" media="all" />'
                         },
                         {
                             pattern: '    <link rel="stylesheet" href="../../css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />',
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
                     sourcemap: 'none'
                 },
                 files: {
-                    'source/css/styles.min.css': 'source/css/scss/styles.scss',
+                    'source/css/styles-<%= pkg.version %>.min.css': 'source/css/scss/styles.scss',
                     'source/css/pattern-scaffolding.min.css': 'source/css/pattern-scaffolding.scss'
                 }
             },
@@ -109,19 +109,26 @@ module.exports = function(grunt) {
                     spawn: true
                 }
             }
+        },
+        gitTag: {
+            // Default: package.json
+            packageFile: 'package.json'
         }
     });
 
     // 3. Where we tell Grunt we plan to use this plug-in.
     //grunt.loadNpmTasks('grunt-contrib-concat');
+
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-sass');
     grunt.loadNpmTasks('grunt-postcss');
     grunt.loadNpmTasks('grunt-shell');
     grunt.loadNpmTasks('grunt-string-replace');
+    grunt.loadNpmTasks('grunt-git-tag');
+
     // 4. Where we tell Grunt what to do when we type "grunt" into the terminal.
-    grunt.registerTask('default', ['sass:dev', 'postcss:dev', 'string-replace:dev','shell:patternlab', 'watch']);
-    grunt.registerTask('dev', ['sass:dev', 'postcss:dev', 'string-replace:dev','shell:patternlab']);
-    grunt.registerTask('prod', ['sass:dist', 'postcss:dist', 'string-replace:dist', 'shell:patternlab']);
+    grunt.registerTask('default', ['sass:dev', 'postcss:dev', 'string-replace:dev','shell:patternlab']);
+    grunt.registerTask('watch', ['sass:dev', 'postcss:dev', 'string-replace:dev','shell:patternlab', 'watch']);
+    grunt.registerTask('release', ['sass:dist', 'postcss:dist', 'string-replace:dist', 'shell:patternlab']);
 
 };

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 
 This pattern library is built using [Pattern Lab 2 Standard Edition for Mustache](https://github.com/pattern-lab/patternlab-php). It contains the source folder for Pattern Lab which includes the mustache files, Sass files and CSS (dependent on Bourbon and Neat), and styles for the pattern lab itself.
 
-## Installation and Generation
+## Installation
 
 * In the command line, at the project root, enter 'npm install' to install node dependencies.
-* To generate the site and set it to watch, enter 'grunt'. This will output expanded CSS with source maps. (Entering 'grunt dev' will do the same, but without the watch state.)
-* To generate production CSS for distribution, enter 'grunt prod'. This will output compressed (i.e. - minified) CSS without source maps.
+
+## Development
+* To generate the site once during developement, simply enter 'grunt'.
+* To put the pattern library into a watch state while developing, enter 'grunt watch' and set it to watch, enter 'grunt'. This will output expanded CSS with source maps. (Entering 'grunt dev' will do the same, but without the watch state.)
+
+## Generate a Tagged Production Release
+To generate production CSS for distribution:
+1. Update the version number of the release in the package.json file. Refer to semver.org for versioning conventions.
+* Generate a compressed (i.e. - minified) CSS without source maps: 'grunt release'.
+* Generate a git tag release and push it up to the remote repository: 'grunt git-tag'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "eul-pattern-lab",
-  "version": "0.1.0",
+  "name": "emory-libraries-pattern-library",
+  "version": "0.5.0",
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/emory-libraries/Pattern-Library.git"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "~0.10.0",
@@ -8,6 +12,7 @@
     "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^1.0.0",
+    "grunt-git-tag": "0.0.5",
     "grunt-postcss": "^0.8.0",
     "grunt-shell": "^1.3.1",
     "grunt-string-replace": "^1.3.1"


### PR DESCRIPTION
Fixes issue #22 
- Adds grunt git-tag command for grunt (see readme.md).
- Leverages version number in package.json.
- Incorporates version number into CSS filename and url.
