### PR TITLE
Grunt tag release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,6 +135,6 @@ module.exports = function(grunt) {
     grunt.registerTask('watch-dev', ['default', 'watch']);
 
     // Production generation task
-    grunt.registerTask('release', ['sass:dist', 'postcss:dist', 'string-replace:dist', 'shell:patternlab']);
+    grunt.registerTask('release', ['sass:dist', 'postcss:dist', 'string-replace:dist', 'shell:patternlab', 'git-tag']);
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emory-libraries-pattern-library",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "repository": {
       "type": "git",
       "url": "https://github.com/emory-libraries/Pattern-Library.git"


### PR DESCRIPTION
- Updates version to 1.1.1
- Adds `git-tag` subcommand to `grunt release` command