### PR TITLE
Adds in noscript version of `organisms-search-menu`

### DIFF
--- a/src/_patterns/20-atoms/forms/30-search.css
+++ b/src/_patterns/20-atoms/forms/30-search.css
@@ -191,7 +191,7 @@ ico,
   display: none;
 }
 .is-default.search-form {
-  display: block;
+  display: grid;
 }
 .search-toggle {
   display: none;

--- a/src/_patterns/20-atoms/forms/30-search.css
+++ b/src/_patterns/20-atoms/forms/30-search.css
@@ -458,6 +458,9 @@ ico,
 .search-cancel.-underline {
   text-decoration: underline;
 }
+.search-cancel[disabled], .search-cancel.is-disabled {
+  opacity: 0.5;
+}
 .search.-contained .search-button {
   border: none;
   border-top-right-radius: 2px;

--- a/src/_patterns/20-atoms/forms/30-search.css
+++ b/src/_patterns/20-atoms/forms/30-search.css
@@ -227,7 +227,7 @@ ico,
 }
 .-form.-contained.search .search-button {
   display: block;
-  grid-area: none;
+  grid-area: button;
 }
 .-contained.search {
   display: grid;

--- a/src/_patterns/20-atoms/forms/30-search.hbs
+++ b/src/_patterns/20-atoms/forms/30-search.hbs
@@ -18,7 +18,8 @@
                 isHover: {{default hover false}},
                 isFocus: {{default focus false}}
               }
-            }">
+            }"
+            v-cloak>
 
   <div class="search{{#if mode}} -{{mode}}{{/if}}{{#if (and layout (eq layout 'contained'))}} -contained{{/if}}">
 

--- a/src/_patterns/20-atoms/forms/30-search.hbs
+++ b/src/_patterns/20-atoms/forms/30-search.hbs
@@ -101,8 +101,6 @@
   <div class="search -form{{#if (and layout (eq layout 'contained'))}} -contained{{/if}}">
   {{#each services as |service|}}
 
-    {{!<input type="radio" name="{{default ../uid ../id}}" id="{{default ../uid ../id}}-{{id}}" class="search-toggle"{{#if service.default}} checked{{/if}}>}}
-
     <form action="{{../processor}}"
           method="GET"
           class="search-form{{#if service.default}} is-default{{/if}}"
@@ -127,9 +125,9 @@
              class="button search-button{{#if ../button.disabled}} is-disabled{{/if}}{{#if ../button.active}} is-active{{/if}}{{#if ../button.hover}} is-hover{{/if}}{{#if ../button.focus}} is-focus{{/if}}"
              {{#if ../button.disabled}}disabled{{/if}}>
 
-      {{#if cancel}}
+      {{#if ../cancel}}
       <input type="reset"
-             value="{{default cancel.label 'Cancel'}}"
+             value="{{default ../cancel.label 'Cancel'}}"
              class="link search-cancel{{#if ../cancel.disabled}} is-disabled{{/if}}{{#if ../cancel.active}} is-active{{/if}}{{#if ../cancel.hover}} is-hover{{/if}}{{#if ../cancel.focus}} is-focus{{/if}}"
              {{#if ../cancel.disabled}}disabled{{/if}}>
       {{/if}}

--- a/src/_patterns/20-atoms/forms/30-search.hbs
+++ b/src/_patterns/20-atoms/forms/30-search.hbs
@@ -66,7 +66,7 @@
       {{/unless}}
     </a>
 
-    {{#if cancelable}}
+    {{#if cancel}}
     <button class="link search-cancel"
             @click="reset"
             @mousedown.native="cancel.isActive = true"
@@ -85,8 +85,9 @@
                'is-focus': cancel.isFocus,
              }"
              :disabled="cancel.isDisabled"
+             {{#if (eq cancel.reveal true)}}v-show="valid"{{/if}}
              tabindex="0">
-      Clear
+      {{default cancel.label 'Cancel'}}
     </button>
     {{/if}}
 
@@ -100,7 +101,7 @@
   <div class="search -form{{#if (and layout (eq layout 'contained'))}} -contained{{/if}}">
   {{#each services as |service|}}
 
-    <input type="radio" name="{{default ../uid ../id}}" id="{{default ../uid ../id}}-{{id}}" class="search-toggle"{{#if service.default}} checked{{/if}}>
+    {{!<input type="radio" name="{{default ../uid ../id}}" id="{{default ../uid ../id}}-{{id}}" class="search-toggle"{{#if service.default}} checked{{/if}}>}}
 
     <form action="{{../processor}}"
           method="GET"
@@ -126,9 +127,9 @@
              class="button search-button{{#if ../button.disabled}} is-disabled{{/if}}{{#if ../button.active}} is-active{{/if}}{{#if ../button.hover}} is-hover{{/if}}{{#if ../button.focus}} is-focus{{/if}}"
              {{#if ../button.disabled}}disabled{{/if}}>
 
-      {{#if cancelable}}
+      {{#if cancel}}
       <input type="reset"
-             value="Cancel"
+             value="{{default cancel.label 'Cancel'}}"
              class="link search-cancel{{#if ../cancel.disabled}} is-disabled{{/if}}{{#if ../cancel.active}} is-active{{/if}}{{#if ../cancel.hover}} is-hover{{/if}}{{#if ../cancel.focus}} is-focus{{/if}}"
              {{#if ../cancel.disabled}}disabled{{/if}}>
       {{/if}}

--- a/src/_patterns/20-atoms/tabs/01-tab.css
+++ b/src/_patterns/20-atoms/tabs/01-tab.css
@@ -343,149 +343,149 @@ ico,
     content: none;
   }
 }
-true-menu:not(.-dropdown).-light .tab {
+.tab-menu:not(.-dropdown).-light .tab, noscript .tab-menu:not(.-dropdown).-light .tab {
   color: #004990;
 }
 @media (max-width: 600px) {
-  true-menu:not(.-dropdown).-light .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  true-menu:not(.-dropdown).-light .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  true-menu:not(.-dropdown).-light .tab::after {
+  .tab-menu:not(.-dropdown).-light .tab::after, noscript .tab-menu:not(.-dropdown).-light .tab::after {
     content: none;
   }
 }
 
-true-menu:not(.-dropdown).-dark .tab {
+.tab-menu:not(.-dropdown).-dark .tab, noscript .tab-menu:not(.-dropdown).-dark .tab {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  true-menu:not(.-dropdown).-dark .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  true-menu:not(.-dropdown).-dark .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  true-menu:not(.-dropdown).-dark .tab::after {
+  .tab-menu:not(.-dropdown).-dark .tab::after, noscript .tab-menu:not(.-dropdown).-dark .tab::after {
     content: none;
   }
 }
 
-.tab:hover, .tab.is-hover, .tab-menu:not(.-dropdown).-light .tab:hover, .tab-menu:not(.-dropdown).-light .tab.is-hover {
+.tab:hover, .tab.is-hover, .tab-menu:not(.-dropdown).-light .tab:hover, .tab-menu:not(.-dropdown).-light .tab.is-hover, noscript .tab-menu:not(.-dropdown).-light .tab:hover, noscript .tab-menu:not(.-dropdown).-light .tab.is-hover {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
+  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before, noscript .tab-menu:not(.-dropdown).-light .tab:hover::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
+  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before, noscript .tab-menu:not(.-dropdown).-light .tab:hover::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab:hover::after, .tab.is-hover::after, .tab-menu:not(.-dropdown).-light .tab:hover::after, .tab-menu:not(.-dropdown).-light .tab.is-hover::after {
+  .tab:hover::after, .tab.is-hover::after, .tab-menu:not(.-dropdown).-light .tab:hover::after, .tab-menu:not(.-dropdown).-light .tab.is-hover::after, noscript .tab-menu:not(.-dropdown).-light .tab:hover::after, noscript .tab-menu:not(.-dropdown).-light .tab.is-hover::after {
     content: none;
   }
 }
-.tab-menu:not(.-dropdown).-dark .tab:hover, .tab-menu:not(.-dropdown).-dark .tab.is-hover {
+.tab-menu:not(.-dropdown).-dark .tab:hover, .tab-menu:not(.-dropdown).-dark .tab.is-hover, noscript .tab-menu:not(.-dropdown).-dark .tab:hover, noscript .tab-menu:not(.-dropdown).-dark .tab.is-hover {
   color: #B6BDCC;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before, noscript .tab-menu:not(.-dropdown).-dark .tab:hover::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before, noscript .tab-menu:not(.-dropdown).-dark .tab:hover::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-dark .tab:hover::after, .tab-menu:not(.-dropdown).-dark .tab.is-hover::after {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::after, .tab-menu:not(.-dropdown).-dark .tab.is-hover::after, noscript .tab-menu:not(.-dropdown).-dark .tab:hover::after, noscript .tab-menu:not(.-dropdown).-dark .tab.is-hover::after {
     content: none;
   }
 }
-.tab:focus, .tab.is-focus, .tab-menu:not(.-dropdown).-light .tab:focus, .tab-menu:not(.-dropdown).-light .tab.is-focus {
+.tab:focus, .tab.is-focus, .tab-menu:not(.-dropdown).-light .tab:focus, .tab-menu:not(.-dropdown).-light .tab.is-focus, noscript .tab-menu:not(.-dropdown).-light .tab:focus, noscript .tab-menu:not(.-dropdown).-light .tab.is-focus {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
+  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before, noscript .tab-menu:not(.-dropdown).-light .tab:focus::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
+  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before, noscript .tab-menu:not(.-dropdown).-light .tab:focus::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab:focus::after, .tab.is-focus::after, .tab-menu:not(.-dropdown).-light .tab:focus::after, .tab-menu:not(.-dropdown).-light .tab.is-focus::after {
+  .tab:focus::after, .tab.is-focus::after, .tab-menu:not(.-dropdown).-light .tab:focus::after, .tab-menu:not(.-dropdown).-light .tab.is-focus::after, noscript .tab-menu:not(.-dropdown).-light .tab:focus::after, noscript .tab-menu:not(.-dropdown).-light .tab.is-focus::after {
     content: none;
   }
 }
-.tab-menu:not(.-dropdown).-dark .tab:focus, .tab-menu:not(.-dropdown).-dark .tab.is-focus {
+.tab-menu:not(.-dropdown).-dark .tab:focus, .tab-menu:not(.-dropdown).-dark .tab.is-focus, noscript .tab-menu:not(.-dropdown).-dark .tab:focus, noscript .tab-menu:not(.-dropdown).-dark .tab.is-focus {
   color: #B6BDCC;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before, noscript .tab-menu:not(.-dropdown).-dark .tab:focus::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before, noscript .tab-menu:not(.-dropdown).-dark .tab:focus::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-dark .tab:focus::after, .tab-menu:not(.-dropdown).-dark .tab.is-focus::after {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::after, .tab-menu:not(.-dropdown).-dark .tab.is-focus::after, noscript .tab-menu:not(.-dropdown).-dark .tab:focus::after, noscript .tab-menu:not(.-dropdown).-dark .tab.is-focus::after {
     content: none;
   }
 }
-.tab:active, .tab.is-active, .tab-menu:not(.-dropdown).-light .tab:active, .tab-menu:not(.-dropdown).-light .tab.is-active {
+.tab:active, .tab.is-active, .tab-menu:not(.-dropdown).-light .tab:active, .tab-menu:not(.-dropdown).-light .tab.is-active, noscript .tab-menu:not(.-dropdown).-light .tab:active, noscript .tab-menu:not(.-dropdown).-light .tab.is-active {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before {
+  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before, noscript .tab-menu:not(.-dropdown).-light .tab:active::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-active::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before {
+  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before, noscript .tab-menu:not(.-dropdown).-light .tab:active::before, noscript .tab-menu:not(.-dropdown).-light .tab.is-active::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .tab:active::after, .tab.is-active::after, .tab-menu:not(.-dropdown).-light .tab:active::after, .tab-menu:not(.-dropdown).-light .tab.is-active::after {
+  .tab:active::after, .tab.is-active::after, .tab-menu:not(.-dropdown).-light .tab:active::after, .tab-menu:not(.-dropdown).-light .tab.is-active::after, noscript .tab-menu:not(.-dropdown).-light .tab:active::after, noscript .tab-menu:not(.-dropdown).-light .tab.is-active::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
   }
 }
-.tab-menu:not(.-dropdown).-dark .tab:active, .tab-menu:not(.-dropdown).-dark .tab.is-active {
+.tab-menu:not(.-dropdown).-dark .tab:active, .tab-menu:not(.-dropdown).-dark .tab.is-active, noscript .tab-menu:not(.-dropdown).-dark .tab:active, noscript .tab-menu:not(.-dropdown).-dark .tab.is-active {
   color: #E9BF55;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
+  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before, noscript .tab-menu:not(.-dropdown).-dark .tab:active::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
+  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before, noscript .tab-menu:not(.-dropdown).-dark .tab:active::before, noscript .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-dark .tab:active::after, .tab-menu:not(.-dropdown).-dark .tab.is-active::after {
+  .tab-menu:not(.-dropdown).-dark .tab:active::after, .tab-menu:not(.-dropdown).-dark .tab.is-active::after, noscript .tab-menu:not(.-dropdown).-dark .tab:active::after, noscript .tab-menu:not(.-dropdown).-dark .tab.is-active::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
@@ -516,42 +516,42 @@ true-menu:not(.-dropdown).-dark .tab {
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab {
+.tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab, noscript .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::after {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::after, noscript .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
 
-.tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab {
+.tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab {
   color: #E9BF55;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::after {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::after, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
@@ -576,40 +576,40 @@ true-menu:not(.-dropdown).-dark .tab {
     content: none;
   }
 }
-.tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab {
+.tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab, noscript .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before, noscript .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::after {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::after, noscript .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::after {
     content: none;
   }
 }
 
-.tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab {
+.tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::after {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::after, noscript .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::after {
     content: none;
   }
 }

--- a/src/_patterns/20-atoms/tabs/01-tab.css
+++ b/src/_patterns/20-atoms/tabs/01-tab.css
@@ -147,43 +147,135 @@ ico,
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
   cursor: pointer;
 }
-.tab::before {
-  content: "";
-  display: block;
-  position: absolute;
-  left: 0;
+@media (min-width: 901px) {
+  .tab {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+  }
+  .tab::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+  }
 }
-.tab::after {
-  content: "";
-  display: block;
-  top: 100%;
-  left: 50%;
-  position: absolute;
-  -webkit-transform: translatey(-50%) translatex(-50%);
-          transform: translatey(-50%) translatex(-50%);
-  z-index: 1;
+@media (max-width: 600px) {
+  .tab:active::before, .is-active.tab::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
 }
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab:active::before, .is-active.tab::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .tab:active::after, .is-active.tab::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .tab-switch:checked + .tab::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-switch:checked + .tab::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .tab-switch:checked + .tab::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+
 .tab-menu {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -ms-flex-wrap: nowrap;
+      flex-wrap: nowrap;
   margin-top: 2em;
   margin-bottom: 2em;
   padding-top: 0.5em;
   padding-bottom: 1em;
+  margin: 0;
 }
-.tab-menu::after {
-  content: "";
-  width: 100%;
-  position: absolute;
-  bottom: 1em;
-  left: 0;
-  right: 0;
+@media (min-width: 901px) {
+  .tab-menu {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+  }
+  .tab-menu::after {
+    content: "";
+    width: 100%;
+    position: absolute;
+    bottom: 1em;
+    left: 0;
+    right: 0;
+  }
 }
 .tab-switch {
   display: none;
@@ -192,6 +284,7 @@ ico,
 .tab {
   -webkit-transition: all 0.25s ease;
   transition: all 0.25s ease;
+  color: #004990;
 }
 .tab {
   font-family: "Open Sans", sans-serif;
@@ -201,103 +294,351 @@ ico,
   line-height: 1.6667;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #605858;
+  color: #004990;
 }
-.tab::before {
-  width: 1px;
-  height: 1em;
+@media (max-width: 600px) {
+  .tab {
+    padding-left: 30px;
+    font-weight: normal;
+    text-transform: none;
+  }
+  .tab::before {
+    width: 30px;
+    height: 30px;
+  }
 }
-.tab + .tab::before {
-  background-color: rgba(96, 88, 88, 0.25);
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab {
+    padding-left: 30px;
+    font-weight: normal;
+    text-transform: none;
+  }
+  .tab::before {
+    width: 30px;
+    height: 30px;
+  }
 }
-.tab:hover, .tab:focus, .tab.is-hover, .tab.is-focus {
+@media (min-width: 901px) {
+  .tab {
+    text-align: center;
+  }
+  .tab + .tab::before {
+    height: 1em;
+    width: 1px;
+    background-color: rgba(182, 189, 204, 0.5);
+  }
+}
+@media (max-width: 600px) {
+  .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab::after {
+    content: none;
+  }
+}
+true-menu:not(.-dropdown).-light .tab {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  true-menu:not(.-dropdown).-light .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  true-menu:not(.-dropdown).-light .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  true-menu:not(.-dropdown).-light .tab::after {
+    content: none;
+  }
+}
+
+true-menu:not(.-dropdown).-dark .tab {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  true-menu:not(.-dropdown).-dark .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  true-menu:not(.-dropdown).-dark .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  true-menu:not(.-dropdown).-dark .tab::after {
+    content: none;
+  }
+}
+
+.tab:hover, .tab.is-hover, .tab-menu:not(.-dropdown).-light .tab:hover, .tab-menu:not(.-dropdown).-light .tab.is-hover {
   color: #336BE6;
 }
-.tab:active, .tab.is-active {
-  color: #082B73;
+@media (max-width: 600px) {
+  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
+    content: none;
+  }
 }
-.tab:active::after, .tab.is-active::after {
-  width: 30px;
-  height: 30px;
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab:hover::before, .tab.is-hover::before, .tab-menu:not(.-dropdown).-light .tab:hover::before, .tab-menu:not(.-dropdown).-light .tab.is-hover::before {
+    content: none;
+  }
 }
-.tab:active::after, .tab.is-active::after {
-  content: url("../icons/php/icon.php?id=material-arrow_drop_down&color=082B73&size[width]=30&size[height]=30");
+@media (min-width: 901px) {
+  .tab:hover::after, .tab.is-hover::after, .tab-menu:not(.-dropdown).-light .tab:hover::after, .tab-menu:not(.-dropdown).-light .tab.is-hover::after {
+    content: none;
+  }
+}
+.tab-menu:not(.-dropdown).-dark .tab:hover, .tab-menu:not(.-dropdown).-dark .tab.is-hover {
+  color: #B6BDCC;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::before, .tab-menu:not(.-dropdown).-dark .tab.is-hover::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-dark .tab:hover::after, .tab-menu:not(.-dropdown).-dark .tab.is-hover::after {
+    content: none;
+  }
+}
+.tab:focus, .tab.is-focus, .tab-menu:not(.-dropdown).-light .tab:focus, .tab-menu:not(.-dropdown).-light .tab.is-focus {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab:focus::before, .tab.is-focus::before, .tab-menu:not(.-dropdown).-light .tab:focus::before, .tab-menu:not(.-dropdown).-light .tab.is-focus::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab:focus::after, .tab.is-focus::after, .tab-menu:not(.-dropdown).-light .tab:focus::after, .tab-menu:not(.-dropdown).-light .tab.is-focus::after {
+    content: none;
+  }
+}
+.tab-menu:not(.-dropdown).-dark .tab:focus, .tab-menu:not(.-dropdown).-dark .tab.is-focus {
+  color: #B6BDCC;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::before, .tab-menu:not(.-dropdown).-dark .tab.is-focus::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-dark .tab:focus::after, .tab-menu:not(.-dropdown).-dark .tab.is-focus::after {
+    content: none;
+  }
+}
+.tab:active, .tab.is-active, .tab-menu:not(.-dropdown).-light .tab:active, .tab-menu:not(.-dropdown).-light .tab.is-active {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab:active::before, .tab.is-active::before, .tab-menu:not(.-dropdown).-light .tab:active::before, .tab-menu:not(.-dropdown).-light .tab.is-active::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .tab:active::after, .tab.is-active::after, .tab-menu:not(.-dropdown).-light .tab:active::after, .tab-menu:not(.-dropdown).-light .tab.is-active::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+.tab-menu:not(.-dropdown).-dark .tab:active, .tab-menu:not(.-dropdown).-dark .tab.is-active {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-dark .tab:active::before, .tab-menu:not(.-dropdown).-dark .tab.is-active::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-dark .tab:active::after, .tab-menu:not(.-dropdown).-dark .tab.is-active::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+  }
 }
 .tab-menu {
-  margin: 0;
+  background-color: #FFFFFF;
 }
 .tab-menu::after {
   height: 1px;
-}
-.tab-menu:not(.-dropdown), .tab-menu.-light:not(.-dropdown) {
-  background-color: #FFFFFF;
-}
-.tab-menu:not(.-dropdown)::after, .tab-menu.-light:not(.-dropdown)::after {
   background-color: rgba(182, 189, 204, 0.5);
-}
-.tab-menu:not(.-dropdown) .tab, .tab-menu.-light:not(.-dropdown) .tab {
-  color: #004990;
-}
-.tab-menu:not(.-dropdown) .tab:hover, .tab-menu:not(.-dropdown) .tab:focus, .tab-menu:not(.-dropdown) .tab.is-hover, .tab-menu:not(.-dropdown) .tab.is-focus, .tab-menu.-light:not(.-dropdown) .tab:hover, .tab-menu.-light:not(.-dropdown) .tab:focus, .tab-menu.-light:not(.-dropdown) .tab.is-hover, .tab-menu.-light:not(.-dropdown) .tab.is-focus {
-  color: #336BE6;
-}
-.tab-menu:not(.-dropdown) .tab:active, .tab-menu:not(.-dropdown) .tab.is-active, .tab-menu.-light:not(.-dropdown) .tab:active, .tab-menu.-light:not(.-dropdown) .tab.is-active {
-  color: #336BE6;
-}
-.tab-menu:not(.-dropdown) .tab:active::after, .tab-menu:not(.-dropdown) .tab.is-active::after, .tab-menu.-light:not(.-dropdown) .tab:active::after, .tab-menu.-light:not(.-dropdown) .tab.is-active::after {
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
-  background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
-}
-.tab-menu:not(.-dropdown) .tab:active::after, .tab-menu:not(.-dropdown) .tab.is-active::after, .tab-menu.-light:not(.-dropdown) .tab:active::after, .tab-menu.-light:not(.-dropdown) .tab.is-active::after {
-  content: url("../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30");
-}
-.tab-menu:not(.-dropdown) .tab + .tab::before, .tab-menu.-light:not(.-dropdown) .tab + .tab::before {
-  background-color: rgba(182, 189, 204, 0.5);
-}
-.tab-menu.-dropdown, .tab-menu.-light.-dropdown {
-  background-color: #FFFFFF;
-}
-.tab-menu.-dark:not(.-dropdown) {
-  background-color: #091C44;
-}
-.tab-menu.-dark:not(.-dropdown)::after {
-  background-color: rgba(231, 234, 241, 0.25);
-}
-.tab-menu.-dark:not(.-dropdown) .tab {
-  color: #FFFFFF;
-}
-.tab-menu.-dark:not(.-dropdown) .tab:hover, .tab-menu.-dark:not(.-dropdown) .tab:focus, .tab-menu.-dark:not(.-dropdown) .tab.is-hover, .tab-menu.-dark:not(.-dropdown) .tab.is-focus {
-  color: #B6BDCC;
-}
-.tab-menu.-dark:not(.-dropdown) .tab:active, .tab-menu.-dark:not(.-dropdown) .tab.is-active {
-  color: #E9BF55;
-}
-.tab-menu.-dark:not(.-dropdown) .tab:active::after, .tab-menu.-dark:not(.-dropdown) .tab.is-active::after {
-  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
-  background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
-}
-.tab-menu.-dark:not(.-dropdown) .tab:active::after, .tab-menu.-dark:not(.-dropdown) .tab.is-active::after {
-  content: url("../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30");
-}
-.tab-menu.-dark:not(.-dropdown) .tab + .tab::before {
-  background-color: rgba(231, 234, 241, 0.25);
-}
-.tab-menu.-dark.-dropdown {
-  background-color: #091C44;
 }
 .tab-switch:checked + .tab {
-  color: #082B73;
+  color: #336BE6;
 }
-.tab-switch:checked + .tab::after {
-  width: 30px;
-  height: 30px;
+@media (max-width: 600px) {
+  .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
 }
-.tab-switch:checked + .tab::after {
-  content: url("../icons/php/icon.php?id=material-arrow_drop_down&color=082B73&size[width]=30&size[height]=30");
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
 }
+@media (min-width: 901px) {
+  .tab-switch:checked + .tab::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:checked + .tab::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+
+.tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:checked + .tab::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+
 .tab-switch:not(:checked) + .tab {
-  color: #605858;
+  color: #004990;
 }
-.tab-switch:not(:checked) + .tab::after {
-  content: none;
+@media (max-width: 600px) {
+  .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab-switch:not(:checked) + .tab::after {
+    content: none;
+  }
+}
+.tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-light .tab-switch:not(:checked) + .tab::after {
+    content: none;
+  }
+}
+
+.tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .tab-menu:not(.-dropdown).-dark .tab-switch:not(:checked) + .tab::after {
+    content: none;
+  }
+}
+
+.tab-menu.-light {
+  background-color: #FFFFFF;
+}
+.tab-menu.-light::after {
+  height: 1px;
+  background-color: rgba(182, 189, 204, 0.5);
+}
+.tab-menu.-light .tab {
+  color: #004990;
+}
+.tab-menu.-light .tab + .tab-menu.-light .tab::before {
+  background-color: rgba(182, 189, 204, 0.5);
+  width: 1px;
+}
+.tab-menu.-dark {
+  background-color: #091C44;
+}
+.tab-menu.-dark::after {
+  height: 1px;
+  background-color: rgba(231, 234, 241, 0.25);
+}
+.tab-menu.-dark .tab {
+  color: #FFFFFF;
+}
+.tab-menu.-dark .tab + .tab-menu.-dark .tab::before {
+  background-color: rgba(231, 234, 241, 0.25);
+  width: 1px;
 }

--- a/src/_patterns/20-atoms/tabs/01-tab.hbs
+++ b/src/_patterns/20-atoms/tabs/01-tab.hbs
@@ -38,7 +38,7 @@
 
 {{#unless (eq noscript true)}}<noscript>{{/unless}}
 
-  <input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
+  {{!<input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>--}}
 
   <label class="tab" for="{{this.uid}}" data-group="{{group}}">{{label}}</label>
 

--- a/src/_patterns/20-atoms/tabs/01-tab.hbs
+++ b/src/_patterns/20-atoms/tabs/01-tab.hbs
@@ -38,7 +38,7 @@
 
 {{#unless (eq noscript true)}}<noscript>{{/unless}}
 
-  {{!<input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>--}}
+  {{#unless search}}<input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>{{/unless}}
 
   <label class="tab" for="{{this.uid}}" data-group="{{group}}">{{label}}</label>
 

--- a/src/_patterns/20-atoms/tabs/01-tab.hbs
+++ b/src/_patterns/20-atoms/tabs/01-tab.hbs
@@ -5,15 +5,17 @@
 {{#if (not group)}}{{assign 'group' (combine 'tab--' (uid))}}{{/if}}
 
 {{#unless (eq noscript true)}}
-  <eul-tab inline-template :defaults="{
-                              isDisabled: {{default disabled false}},
-                              isActive: {{default active false}},
-                              isHover: {{default hover false}},
-                              isFocus: {{default focus false}}
-                            }"
-                            :uid="{{JSONstringify this.uid}}"
-                            {{#if menu}}:menu="{{JSONstringify menu}}"{{/if}}
-                            {{#if value}}:value="{{JSONstringify value}}"{{/if}}>
+  <eul-tab inline-template
+           :defaults="{
+             isDisabled: {{default disabled false}},
+             isActive: {{default active false}},
+             isHover: {{default hover false}},
+             isFocus: {{default focus false}}
+           }"
+           :uid="{{JSONstringify this.uid}}"
+           {{#if menu}}:menu="{{JSONstringify menu}}"{{/if}}
+           {{#if value}}:value="{{JSONstringify value}}"{{/if}}
+           v-cloak>
 
     <button @click="activate"
             @keypress.enter="click"
@@ -38,7 +40,9 @@
 
 {{#unless (eq noscript true)}}<noscript>{{/unless}}
 
-  {{#unless search}}<input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>{{/unless}}
+  {{#if (not (eq search true))}}
+    <input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
+  {{/if}}
 
   <label class="tab" for="{{this.uid}}" data-group="{{group}}">{{label}}</label>
 

--- a/src/_patterns/40-compounds/tabs/tab-menu.css
+++ b/src/_patterns/40-compounds/tabs/tab-menu.css
@@ -145,11 +145,11 @@ ico,
   -ms-flex-wrap: nowrap;
       flex-wrap: nowrap;
 }
-.tab-menu:not(.-dropdown) {
+.tab-menu:not(.-dropdown):not(.-noscript) {
   display: none;
 }
 @media (min-width: 901px) {
-  .tab-menu:not(.-dropdown) {
+  .tab-menu:not(.-dropdown):not(.-noscript) {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
@@ -180,6 +180,20 @@ ico,
 @media (min-width: 901px) {
   .-dropdown.tab-menu {
     display: none;
+  }
+}
+.-noscript.tab-menu {
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+}
+@media (min-width: 901px) {
+  .-noscript.tab-menu {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
   }
 }
 

--- a/src/_patterns/40-compounds/tabs/tab-menu.hbs
+++ b/src/_patterns/40-compounds/tabs/tab-menu.hbs
@@ -17,7 +17,7 @@
 
 {{! Determine the active tab. }}
 {{#if (gt (length (filterWhere tabs 'selected' true '===')) 0)}}
-  {{assign 'selected' (itemAt (filterWhere tabs 'selected' true) 0)}}
+  {{assign 'selected' (itemAt (filterWhere tabs 'selected' true '===') 0)}}
 {{else}}
   {{assign 'selected' (itemAt tabs 0)}}
 {{/if}}
@@ -69,15 +69,11 @@
 {{/unless}}
 
 {{#unless (eq noscript true)}}<noscript>{{/unless}}
-  <div class="tab-menu">
+  <div class="tab-menu -noscript">
     {{#each tabs}}
 
-      {{! Determine if the tab should be active. }}
-      {{#if (eq ../selected.uid this.uid)}}
-        {{assign 'active' true}}
-      {{else}}
-        {{assign 'active' false}}
-      {{/if}}
+    {{! Determine if the tab should be active. }}
+    {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}
 
       {{> atoms-tab noscript=true uid=this.uid group=../uid}}
 

--- a/src/_patterns/40-compounds/tabs/tab-menu.hbs
+++ b/src/_patterns/40-compounds/tabs/tab-menu.hbs
@@ -22,18 +22,17 @@
   {{assign 'selected' (itemAt tabs 0)}}
 {{/if}}
 
-{{! Determine if the tab menu is part of a search menu. }}
-{{#if relay}}{{assign 'search' true}}{{else}}{{assign 'search' false}}{{/if}}
-
 {{#unless (eq noscript true)}}
-  <eul-tab-menu inline-template :defaults="{
-                                  selected: {
-                                    value: {{JSONstringify selected.value}},
-                                    uid: {{JSONstringify selected.uid}}
-                                  }
-                                }"
-                                :relay="{{#if relay}}{{JSONstringify relay}}{{else}}null{{/if}}"
-                                :uid="{{JSONstringify this.uid}}">
+  <eul-tab-menu inline-template
+                :defaults="{
+                  selected: {
+                    value: {{JSONstringify selected.value}},
+                    uid: {{JSONstringify selected.uid}}
+                  }
+                }"
+                :relay="{{#if relay}}{{JSONstringify relay}}{{else}}null{{/if}}"
+                :uid="{{JSONstringify this.uid}}"
+                v-cloak>
 
     <div>
 
@@ -44,7 +43,7 @@
           {{! Determine if the tab should be active. }}
           {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
-          {{> atoms-tab menu=../uid}}
+          {{> atoms-tab menu=../uid search=(default ../search false)}}
 
         {{/each}}
       </div>
@@ -74,7 +73,7 @@
     {{! Determine if the tab should be active. }}
     {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
-      {{> atoms-tab noscript=true uid=this.uid group=../uid search=../search}}
+      {{> atoms-tab noscript=true uid=this.uid group=../uid search=(default ../search false)}}
 
     {{/each}}
   </div>

--- a/src/_patterns/40-compounds/tabs/tab-menu.hbs
+++ b/src/_patterns/40-compounds/tabs/tab-menu.hbs
@@ -4,8 +4,8 @@
 {{! Generate unique IDs for the tab menu items. }}
 {{#each tabs}}
 
-  {{! Generate a unique ID for the tab menu item. }}
-  {{assign 'uid' (combine 'tab--' (dashcase (lowercase label)))}}
+  {{! Generate a unique ID for the tab if not already given. }}
+  {{#if (not this.uid)}}{{assign 'uid' (combine 'tab--' (dashcase (lowercase label)))}}{{/if}}
 
   {{! Save the updated tab menu items. }}
   {{storagePush 'tabs' this}}
@@ -21,6 +21,9 @@
 {{else}}
   {{assign 'selected' (itemAt tabs 0)}}
 {{/if}}
+
+{{! Determine if the tab menu is part of a search menu. }}
+{{#if relay}}{{assign 'search' true}}{{else}}{{assign 'search' false}}{{/if}}
 
 {{#unless (eq noscript true)}}
   <eul-tab-menu inline-template :defaults="{
@@ -39,11 +42,7 @@
         {{#each tabs}}
 
           {{! Determine if the tab should be active. }}
-          {{#if (eq ../selected.uid this.uid)}}
-            {{assign 'active' true}}
-          {{else}}
-            {{assign 'active' false}}
-          {{/if}}
+          {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
           {{> atoms-tab menu=../uid}}
 
@@ -69,13 +68,13 @@
 {{/unless}}
 
 {{#unless (eq noscript true)}}<noscript>{{/unless}}
-  <div class="tab-menu -noscript">
+  <div class="tab-menu -noscript{{#if theme}} -{{theme}}{{/if}}">
     {{#each tabs}}
 
     {{! Determine if the tab should be active. }}
-    {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}
+    {{#if (eq ../selected.uid this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
-      {{> atoms-tab noscript=true uid=this.uid group=../uid}}
+      {{> atoms-tab noscript=true uid=this.uid group=../uid search=../search}}
 
     {{/each}}
   </div>

--- a/src/_patterns/50-organisms/intros/intro~home.css
+++ b/src/_patterns/50-organisms/intros/intro~home.css
@@ -149,7 +149,6 @@ ico,
   -ms-flex-item-align: stretch;
       align-self: stretch;
   margin: 0 !important;
-  padding-top: 0.5em;
 }
 .intro-home-search .search-menu {
   padding-top: 0;
@@ -158,6 +157,7 @@ ico,
   .intro-home-search {
     padding-left: 6em;
     padding-right: 6em;
+    padding-top: 0.5em;
   }
 }
 .intro-home-badge {

--- a/src/_patterns/50-organisms/intros/intro~home.css
+++ b/src/_patterns/50-organisms/intros/intro~home.css
@@ -136,8 +136,8 @@ ico,
 
 .intro-home {
   display: grid;
-  grid-template-rows: 180px -webkit-min-content 6fr repeat(2, -webkit-min-content) 1fr;
-  grid-template-rows: 180px min-content 6fr repeat(2, min-content) 1fr;
+  grid-template-rows: minmax(180px, -webkit-min-content) -webkit-min-content 6fr repeat(2, -webkit-min-content) 1fr;
+  grid-template-rows: minmax(180px, min-content) min-content 6fr repeat(2, min-content) 1fr;
   grid-template-columns: 1fr 2fr minmax(-webkit-min-content, 800px) 2fr 1fr;
   grid-template-columns: 1fr 2fr minmax(min-content, 800px) 2fr 1fr;
   background-size: cover;

--- a/src/_patterns/50-organisms/intros/intro~home.css
+++ b/src/_patterns/50-organisms/intros/intro~home.css
@@ -141,6 +141,7 @@ ico,
   grid-template-columns: 1fr 2fr minmax(-webkit-min-content, 800px) 2fr 1fr;
   grid-template-columns: 1fr 2fr minmax(min-content, 800px) 2fr 1fr;
   background-size: cover;
+  background-position: center;
   height: 845px;
 }
 .intro-home-search {

--- a/src/_patterns/50-organisms/navigation/search-menu.css
+++ b/src/_patterns/50-organisms/navigation/search-menu.css
@@ -177,6 +177,8 @@ ico,
 }
 .search-menu-context {
   grid-area: context;
+  margin-top: 2em;
+  margin-bottom: 2em;
 }
 @media (min-width: 901px) {
   .search-menu-context {
@@ -186,7 +188,7 @@ ico,
 .search-menu-tabs {
   grid-area: tabs;
 }
-.search-menu-search {
+.search-menu-search, .search-menu-search noscript {
   grid-area: search;
   display: -webkit-box;
   display: -ms-flexbox;
@@ -194,6 +196,7 @@ ico,
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
+  width: 100%;
 }
 .search-menu-search .search {
   width: 100%;
@@ -225,7 +228,7 @@ ico,
   }
 }
 .-home.search-menu .search-menu-back {
-  display: none;
+  display: none !important;
 }
 .search-menu-toggle {
   display: none;
@@ -341,11 +344,13 @@ ico,
   -webkit-transition: none !important;
   transition: none !important;
 }
-.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1) {
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: "";
     display: block;
     position: absolute;
@@ -358,7 +363,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: "";
     display: block;
     position: absolute;
@@ -371,7 +377,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::after {
     content: "";
     display: block;
     top: 100%;
@@ -383,27 +390,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
     content: "";
     display: block;
     position: absolute;
@@ -416,7 +428,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
     content: "";
     display: block;
     position: absolute;
@@ -429,7 +442,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::after {
     content: "";
     display: block;
     top: 100%;
@@ -441,69 +455,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-search .search .search-form:nth-of-type(1) {
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-search .search .search-form:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(1) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1) {
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(1)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1) {
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(1)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after,
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(1)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(1) {
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(1),
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(1) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2) {
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: "";
     display: block;
     position: absolute;
@@ -516,7 +632,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: "";
     display: block;
     position: absolute;
@@ -529,7 +646,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::after {
     content: "";
     display: block;
     top: 100%;
@@ -541,27 +659,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
     content: "";
     display: block;
     position: absolute;
@@ -574,7 +697,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
     content: "";
     display: block;
     position: absolute;
@@ -587,7 +711,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::after {
     content: "";
     display: block;
     top: 100%;
@@ -599,69 +724,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-search .search .search-form:nth-of-type(2) {
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-search .search .search-form:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(2) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2) {
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(2)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2) {
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(2)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after,
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(2)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(2) {
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(2),
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(2) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3) {
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: "";
     display: block;
     position: absolute;
@@ -674,7 +901,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: "";
     display: block;
     position: absolute;
@@ -687,7 +915,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::after {
     content: "";
     display: block;
     top: 100%;
@@ -699,27 +928,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
     content: "";
     display: block;
     position: absolute;
@@ -732,7 +966,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
     content: "";
     display: block;
     position: absolute;
@@ -745,7 +980,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::after {
     content: "";
     display: block;
     top: 100%;
@@ -757,69 +993,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-search .search .search-form:nth-of-type(3) {
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-search .search .search-form:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(3) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3) {
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(3)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3) {
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(3)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after,
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(3)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(3) {
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(3),
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(3) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4) {
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: "";
     display: block;
     position: absolute;
@@ -832,7 +1170,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: "";
     display: block;
     position: absolute;
@@ -845,7 +1184,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::after {
     content: "";
     display: block;
     top: 100%;
@@ -857,27 +1197,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
     content: "";
     display: block;
     position: absolute;
@@ -890,7 +1235,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
     content: "";
     display: block;
     position: absolute;
@@ -903,7 +1249,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::after {
     content: "";
     display: block;
     top: 100%;
@@ -915,69 +1262,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-search .search .search-form:nth-of-type(4) {
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-search .search .search-form:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(4) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4) {
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(4)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4) {
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(4)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after,
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(4)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(4) {
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(4),
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(4) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5) {
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: "";
     display: block;
     position: absolute;
@@ -990,7 +1439,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1003,7 +1453,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1015,27 +1466,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1048,7 +1504,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1061,7 +1518,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1073,69 +1531,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-search .search .search-form:nth-of-type(5) {
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-search .search .search-form:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(5) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5) {
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(5)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5) {
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(5)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after,
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(5)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(5) {
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(5),
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(5) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6) {
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1148,7 +1708,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1161,7 +1722,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1173,27 +1735,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1206,7 +1773,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1219,7 +1787,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1231,69 +1800,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-search .search .search-form:nth-of-type(6) {
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-search .search .search-form:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(6) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6) {
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(6)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6) {
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(6)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after,
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(6)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(6) {
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(6),
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(6) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7) {
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1306,7 +1977,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1319,7 +1991,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1331,27 +2004,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1364,7 +2042,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1377,7 +2056,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1389,69 +2069,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-search .search .search-form:nth-of-type(7) {
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-search .search .search-form:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(7) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7) {
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(7)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7) {
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(7)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after,
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(7)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(7) {
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(7),
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(7) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8) {
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1464,7 +2246,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1477,7 +2260,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1489,27 +2273,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1522,7 +2311,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1535,7 +2325,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1547,69 +2338,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-search .search .search-form:nth-of-type(8) {
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-search .search .search-form:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(8) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8) {
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(8)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8) {
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(8)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after,
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(8)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(8) {
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(8),
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(8) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9) {
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1622,7 +2515,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1635,7 +2529,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1647,27 +2542,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1680,7 +2580,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1693,7 +2594,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1705,69 +2607,171 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-search .search .search-form:nth-of-type(9) {
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-search .search .search-form:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(9) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9) {
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(9)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9) {
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(9)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after,
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(9)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(9) {
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(9),
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(9) {
   display: none;
 }
-.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10) {
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10) {
   color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1780,7 +2784,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1793,7 +2798,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1805,27 +2811,32 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10) {
-  color: #E9BF55;
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10) {
+  color: #336BE6;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1838,7 +2849,8 @@ ico,
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
     content: "";
     display: block;
     position: absolute;
@@ -1851,7 +2863,8 @@ ico,
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::after {
     content: "";
     display: block;
     top: 100%;
@@ -1863,62 +2876,162 @@ ico,
   }
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
     content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::after {
     content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
     background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
   }
 }
-.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-search .search .search-form:nth-of-type(10) {
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-search .search .search-form:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-search noscript .search .search-form:nth-of-type(10) {
   display: grid;
 }
-.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10) {
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10) {
   color: #004990;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu .tab:nth-of-type(10)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10) {
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-light .tab:nth-of-type(10)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10) {
   color: #FFFFFF;
 }
 @media (max-width: 600px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
     content: none;
   }
 }
 @media (min-width: 601px) and (max-width: 900px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::before {
     content: none;
   }
 }
 @media (min-width: 901px) {
-  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after,
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs noscript .tab-menu.-dark .tab:nth-of-type(10)::after {
     content: none;
   }
 }
-.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(10) {
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(10),
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-search noscript .search .search-form:nth-of-type(10) {
   display: none;
 }
 .search-menu.-light {

--- a/src/_patterns/50-organisms/navigation/search-menu.css
+++ b/src/_patterns/50-organisms/navigation/search-menu.css
@@ -177,8 +177,8 @@ ico,
 }
 .search-menu-context {
   grid-area: context;
-  margin-top: 2em;
-  margin-bottom: 2em;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 @media (min-width: 901px) {
   .search-menu-context {

--- a/src/_patterns/50-organisms/navigation/search-menu.css
+++ b/src/_patterns/50-organisms/navigation/search-menu.css
@@ -227,6 +227,9 @@ ico,
 .-home.search-menu .search-menu-back {
   display: none;
 }
+.search-menu-toggle {
+  display: none;
+}
 
 .search-menu {
   padding-left: 25px;
@@ -337,6 +340,1586 @@ ico,
   background-color: transparent !important;
   -webkit-transition: none !important;
   transition: none !important;
+}
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(1):checked ~ .search-menu-search .search .search-form:nth-of-type(1) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(1)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(1)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(1):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(1) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(2):checked ~ .search-menu-search .search .search-form:nth-of-type(2) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(2)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(2)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(2):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(2) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(3):checked ~ .search-menu-search .search .search-form:nth-of-type(3) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(3)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(3)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(3):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(3) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(4):checked ~ .search-menu-search .search .search-form:nth-of-type(4) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(4)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(4)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(4):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(4) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(5):checked ~ .search-menu-search .search .search-form:nth-of-type(5) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(5)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(5)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(5):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(5) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(6):checked ~ .search-menu-search .search .search-form:nth-of-type(6) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(6)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(6)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(6):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(6) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(7):checked ~ .search-menu-search .search .search-form:nth-of-type(7) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(7)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(7)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(7):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(7) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(8):checked ~ .search-menu-search .search .search-form:nth-of-type(8) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(8)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(8)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(8):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(8) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(9):checked ~ .search-menu-search .search .search-form:nth-of-type(9) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(9)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(9)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(9):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(9) {
+  display: none;
+}
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10) {
+  color: #336BE6;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=336BE6&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=336BE6&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #FFFFFF), color-stop(55%, #FFFFFF), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #FFFFFF 45%, #FFFFFF 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10) {
+  color: #E9BF55;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: "";
+    display: block;
+    position: absolute;
+    left: 0;
+    position: absolute;
+    display: block;
+    top: 50%;
+    -webkit-transform: translatey(-50%);
+            transform: translatey(-50%);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+    content: "";
+    display: block;
+    top: 100%;
+    left: 50%;
+    position: absolute;
+    -webkit-transform: translatey(-50%) translatex(-50%);
+            transform: translatey(-50%) translatex(-50%);
+    z-index: 1;
+  }
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: url(../icons/php/icon.php?id=material-arrow_right&color=E9BF55&size[width]=30&size[height]=30);
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):checked ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+    content: url(../icons/php/icon.php?id=material-arrow_drop_down&color=E9BF55&size[width]=30&size[height]=30);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(45%, transparent), color-stop(45%, #091C44), color-stop(55%, #091C44), color-stop(55%, transparent));
+    background-image: linear-gradient(to bottom, transparent 45%, #091C44 45%, #091C44 55%, transparent 55%);
+  }
+}
+.search-menu-toggle:nth-of-type(10):checked ~ .search-menu-search .search .search-form:nth-of-type(10) {
+  display: grid;
+}
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10) {
+  color: #004990;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-light .tab:nth-of-type(10)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10) {
+  color: #FFFFFF;
+}
+@media (max-width: 600px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 601px) and (max-width: 900px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::before {
+    content: none;
+  }
+}
+@media (min-width: 901px) {
+  .search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-tabs .tab-menu.-dark .tab:nth-of-type(10)::after {
+    content: none;
+  }
+}
+.search-menu-toggle:nth-of-type(10):not(:checked) ~ .search-menu-search .search .search-form:nth-of-type(10) {
+  display: none;
 }
 .search-menu.-light {
   background-color: #FFFFFF;

--- a/src/_patterns/50-organisms/navigation/search-menu.hbs
+++ b/src/_patterns/50-organisms/navigation/search-menu.hbs
@@ -1,5 +1,3 @@
-{{assign 'noscript' true}}
-
 {{! Generate a unique ID for the search box. }}
 {{assign 'searchUID' (uid 'search--')}}
 
@@ -44,7 +42,7 @@
       {{! Determine if the tab should be active. }}
       {{#if (eq ../selected this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
-      <input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
+      <input type="radio" class="search-menu-toggle" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
 
     {{/each}}
   {{/if}}

--- a/src/_patterns/50-organisms/navigation/search-menu.hbs
+++ b/src/_patterns/50-organisms/navigation/search-menu.hbs
@@ -36,21 +36,21 @@
 
 <div class="search-menu -{{default theme 'dark'}}{{#if home}} -home{{/if}}" data-uid="{{this.uid}}">
 
-  {{#if (eq noscript true)}}
-    {{#each tabs}}
+  {{! Always add toggles for tabs and search boxes. }}
+  {{! NOTE: This is required to enable noscript functionality. }}
+  {{#each tabs}}
 
-      {{! Determine if the tab should be active. }}
-      {{#if (eq ../selected this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
+    {{! Determine if the tab should be active. }}
+    {{#if (eq ../selected this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
 
-      <input type="radio" class="search-menu-toggle" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
+    <input type="radio" class="search-menu-toggle" id="{{this.uid}}" name="{{group}}"{{#if active}} checked{{/if}}>
 
-    {{/each}}
-  {{/if}}
+  {{/each}}
 
   <span class="search-menu-context">{{default context 'Searching:'}}</span>
 
   <div class="search-menu-tabs">
-    {{> compounds-tab-menu theme=(default theme 'dark') relay=searchUID}}
+    {{> compounds-tab-menu theme=(default theme 'dark') relay=searchUID search=true}}
   </div>
 
   <div class="search-menu-search">

--- a/src/_patterns/50-organisms/navigation/search-menu.hbs
+++ b/src/_patterns/50-organisms/navigation/search-menu.hbs
@@ -1,24 +1,70 @@
-{{!assign 'noscript' true}}
+{{assign 'noscript' true}}
 
 {{! Generate a unique ID for the search box. }}
 {{assign 'searchUID' (uid 'search--')}}
+
+{{! Generate a unique group ID for tabs. }}
+{{assign 'tabUID' (uid 'tab--')}}
+
+{{! Generate unique IDs for tabs. }}
+{{#each tabs}}
+
+  {{! Assign the tab a unique ID based on its value, which should map to a search field. }}
+  {{assign 'uid' (combine 'search-menu-toggle--' (dashcase (lowercase value)))}}
+
+  {{! Add the tabs' unique group ID as the group name. }}
+  {{assign 'group' ../tabUID}}
+
+  {{! Save the updated tab's unique ID. }}
+  {{storagePush 'tabs' this}}
+
+{{/each}}
+
+{{! Update tabs with their unique IDs. }}
+{{assign 'tabs' (storageGet 'tabs')}}
+
+{{! Determine which tab should be selected by default. }}
+{{! NOTE: This is typically handled at the tab menu level, which is fine when JS is enabled, but we need it here for noscript scenarios. }}
+{{#if (gt (length (filterWhere tabs 'selected' true '===')) 0)}}
+  {{assign 'selected' (get 'uid' (itemAt (filterWhere tabs 'selected' true '===') 0))}}
+{{else if (gt (length (filterWhere services 'default' true '===')) 0)}}
+  {{assign 'selected' (combine 'search-menu-toggle--' (get 'id' (itemAt (filterWhere services 'default' true '===') 0)))}}
+{{else}}
+  {{assign 'selected' (get 'uid' (itemAt tabs 0))}}
+{{/if}}
 
 {{! Determine if a search form should be used instead of the default. }}
 {{#if (eq noscript true)}}{{assign 'form' true}}{{/if}}
 
 <div class="search-menu -{{default theme 'dark'}}{{#if home}} -home{{/if}}" data-uid="{{this.uid}}">
+
+  {{#if (eq noscript true)}}
+    {{#each tabs}}
+
+      {{! Determine if the tab should be active. }}
+      {{#if (eq ../selected this.uid)}}{{assign 'active' true}}{{else}}{{assign 'active' false}}{{/if}}
+
+      <input type="radio" class="tab-switch" id="{{this.uid}}" name="{{group}}" value="{{this.uid}}"{{#if active}} checked{{/if}}>
+
+    {{/each}}
+  {{/if}}
+
   <span class="search-menu-context">{{default context 'Searching:'}}</span>
+
   <div class="search-menu-tabs">
     {{> compounds-tab-menu theme=(default theme 'dark') relay=searchUID}}
   </div>
+
   <div class="search-menu-search">
     {{#unless home}}
-      {{> atoms-search mode='small' layout=false cancelable=true uid=searchUID}}
+      {{> atoms-search mode='small' layout=false cancel=(objectify label=(default cancel 'Cancel')) uid=searchUID}}
     {{else}}
-      {{> atoms-search mode='big' layout='contained' uid=searchUID}}
+      {{> atoms-search mode='big' layout='contained' cancel=(objectify label=(default cancel 'Cancel')) uid=searchUID}}
     {{/unless}}
   </div>
+
   <div class="search-menu-back">
     {{#with back}}{{> atoms-button-toggle classes='search-menu-back' for=this.uid}}{{/with}}
   </div>
+
 </div>

--- a/src/_patterns/50-organisms/navigation/search-menu.json
+++ b/src/_patterns/50-organisms/navigation/search-menu.json
@@ -1,5 +1,4 @@
 {
-
   "back": {
     "label": "Back to Menu",
     "icon": {
@@ -77,5 +76,6 @@
     "icon": "material-search",
     "label": "Search"
   },
+  "cancel": "Clear",
   "processor": "/php/example-search.php"
 }

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/search/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/search/_skin.scss
@@ -323,6 +323,12 @@ $atoms-search: (
     @include atoms-link;
     margin-left: $spacing;
     text-decoration: underline !important;
+
+    &[disabled],
+    &.is-disabled {
+      opacity: $alpha;
+    }
+
   }
 
   // Defines contained search styles.
@@ -351,8 +357,6 @@ $atoms-search: (
   }
 
   // Defines form search styles.
-  &.-form {
-
-  }
+  &.-form {}
 
 }

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/search/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/search/_structure.scss
@@ -125,7 +125,7 @@
     // Modifies structure for search button.
     #{$selector}-button {
       display: block;
-      grid-area: none;
+      grid-area: button;
     }
 
   }

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/search/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/search/_structure.scss
@@ -65,7 +65,7 @@
 
     // Modifies structure when active.
     &.is-default {
-      display: block;
+      display: grid;
     }
 
   }

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_skin.scss
@@ -222,10 +222,14 @@ $atoms-tab: (
         '&:#{$state}',
         '&.is-#{$state}',
         '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
-        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}',
+        'noscript #{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
+        'noscript #{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
       ), ', '), glue((
         '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
-        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}',
+        'noscript #{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
+        'noscript #{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
       ), ', ')));
 
       // Apply all state-specific styles for the given theme.
@@ -355,10 +359,75 @@ $atoms-tab: (
 
       }
 
-      @if( $selector != false ) {
+      @if( $selector == true ) {
 
         // Also, add state-specific styles within its themed menu.
-        @at-root #{$selector}-menu:not(.-dropdown).-#{$theme} & {
+        @at-root &-menu:not(.-dropdown).-#{$theme} &,
+        noscript &-menu:not(.-dropdown).-#{$theme} & {
+          color: $state-foreground;
+
+          // Add an indicator when active.
+          @if( $state == 'active' ) {
+
+            // For smaller screens, add indicators at the left of the tab.
+            @include breakpoint-s-m {
+
+              &::before {
+                content: icon-url('material-arrow_right', $state-foreground, $indicator);
+              };
+
+            };
+
+            // For larger screens, add indicators below the tab.
+            @include breakpoint-l {
+
+              &::after {
+                content: icon-url('material-arrow_drop_down', $state-foreground, $indicator);
+                @include linear-gradient(
+                  to bottom,
+                  transparent 45%,
+                  $theme-background 45%,
+                  $theme-background 55%,
+                  transparent 55%
+                );
+              }
+
+            };
+
+          }
+
+          // Otherwise, remove indicators when not active.
+          @else {
+
+            // For smaller screens, remove indicators at the left of the tab.
+            @include breakpoint-s-m {
+
+              &::before {
+                content: none;
+              };
+
+            };
+
+            // For larger screens, remove indicators below the tab.
+            @include breakpoint-l {
+
+              &::after {
+                content: none;
+              }
+
+            };
+
+          }
+
+        }
+
+      }
+
+      @else if( $selector != false ) {
+
+        // Also, add state-specific styles within its themed menu.
+        @at-root #{$selector}-menu:not(.-dropdown).-#{$theme} &,
+        noscript #{$selector}-menu:not(.-dropdown).-#{$theme} & {
           color: $state-foreground;
 
           // Add an indicator when active.

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_skin.scss
@@ -9,44 +9,38 @@
 /// @type map
 $atoms-tab: (
 
-  'thickness': $border-width-s,
   'transition': (
     'duration': $transition-duration,
     'timing': $transition-timing
   ),
-  'divider': (
-    'size': 1em
-  ),
-  'indicator': (
-    'size': 30px,
-    'start': 45%,
-    'stop': 55%
-  ),
-  'color': (
-    'default': $color-text-dark,
-    'hover': $color-actionable,
-    'active': color('blue')
-  ),
-  'border': rgba(color('charcoal'), .25),
+  'divider': 1em,
+  'indicator': 30px,
 
-  'theme': (
+  'theme': "light",
+  "themes": (
     'light': (
       'background': color('white'),
       'foreground': (
-        'default': color('blue', 'mid'),
+        'normal': color('blue', 'mid'),
         'hover': $color-actionable,
         'active': $color-actionable
       ),
-      'border': rgba(color('slate'), .5)
+      'border': (
+        'color': rgba(color('slate'), .5),
+        'thickness': $border-width-s
+      )
     ),
     'dark': (
       'background': color('blue', 'dark'),
       'foreground': (
-        'default': color('white'),
+        'normal': color('white'),
         'hover': color('slate'),
         'active': color('gold')
       ),
-      'border': rgba(color('slate', 'light'), .25)
+      'border': (
+        'color': rgba(color('slate', 'light'), .25),
+        'thickness': $border-width-s
+      )
     )
   )
 
@@ -72,188 +66,64 @@ $atoms-tab: (
   $selector: &;
 
   // Captures themeable variables.
-  $thickness: map-deep-get($skin, 'thickness');
-  $duration: map-deep-get($skin, 'transition.duration');
-  $timing: map-deep-get($skin, 'transition.timing');
-  $default: map-deep-get($skin, 'color.default');
-  $hover: map-deep-get($skin, 'color.hover');
-  $active: map-deep-get($skin, 'color.active');
-  $border: map-deep-get($skin, 'border');
+  $theme: map-deep-get($skin, 'theme');
+  $themes: map-deep-get($skin, 'themes');
+  $divider: map-deep-get($skin, 'divider');
+  $indicator: map-deep-get($skin, 'indicator');
+
+  // Get transition-specific variables.
+  $transition-duration: map-deep-get($skin, 'transition.duration');
+  $transition-timing: map-deep-get($skin, 'transition.timing');
+
+  // Get theme-specific variables.
+  $theme-foreground: map-deep-get($themes, $theme + '.foreground.normal');
+  $theme-background: map-deep-get($themes, $theme + '.background');
+  $theme-border-color: map-deep-get($themes, $theme + '.border.color');
+  $theme-border-thickness: map-deep-get($themes, $theme + '.border.thickness');
 
   // Build tab component styles.
-  @include tokens-heading('h6', $default);
-  transition: all $duration $timing;
+  @include tokens-heading('h6', $theme-foreground);
+  transition: all $transition-duration $transition-timing;
 
-  // Capture tab-specific variables.
-  $divider-size: map-deep-get($skin, 'divider.size');
-  $indicator-size: map-deep-get($skin, 'indicator.size');
-  $indicator-start: map-deep-get($skin, 'indicator.start');
-  $indicator-stop: map-deep-get($skin, 'indicator.stop');
+  // Builds styles for smaller screens.
+  @include breakpoint-s-m {
+    padding-left: $indicator;
+    font-weight: normal;
+    text-transform: none;
 
-  // Builds styles between subsequent tabs.
-  &::before {
-    width: $thickness;
-    height: $divider-size;
-  }
-
-  // Add left border to subsequent tabs.
-  & + &::before {
-    background-color: $border;
-  }
-
-  // Builds styles for hovered/focused tabs.
-  &:hover,
-  &:focus,
-  &.is-hover,
-  &.is-focus {
-    color: $hover;
-  }
-
-  // Builds styles for active tabs.
-  &:active,
-  &.is-active {
-    color: $active;
-
-    // Displays indicator when active.
-    &::after {
-      @include tokens-icon('material-arrow_drop_down', $active, $indicator-size, $pseudo: true);
-      @include size( $indicator-size );
+    &::before {
+      @include size($indicator);
     }
 
-  }
+  };
+
+  // Builds styles for larger screens.
+  @include breakpoint-l {
+    text-align: center;
+
+    // Add divider between subsequent tabs.
+    & + &::before {
+      height: $divider;
+      width: $theme-border-thickness;
+      background-color: $theme-border-color;
+    }
+
+  };
+
+  // Add tab states.
+  @include atoms-tab--state('normal', $skin);
+  @include atoms-tab--state('hover', $skin);
+  @include atoms-tab--state('focus', $skin);
+  @include atoms-tab--state('active', $skin);
 
   // Build tab menu styles.
   &-menu {
-    margin: 0;
+    background-color: $theme-background;
 
-    // Build horizontal rule styles.
+    // Add a horizontal rule to the tab menu.
     &::after {
-      height: $thickness;
-    }
-
-    // Build light theme menu styles.
-    &,
-    &.-light {
-      $theme-background: map-deep-get($skin, 'theme.light.background');
-      $theme-border: map-deep-get($skin, 'theme.light.border');
-      $theme-default: map-deep-get($skin, 'theme.light.foreground.default');
-      $theme-hover: map-deep-get($skin, 'theme.light.foreground.hover');
-      $theme-active: map-deep-get($skin, 'theme.light.foreground.active');
-
-      &:not(.-dropdown) {
-        background-color: $theme-background;
-
-        // Styles the horizontal rule under the menu.
-        &::after {
-          background-color: $theme-border;
-        }
-
-        // Styles tabs when inside a light-themed menu.
-        #{$selector} {
-          color: $theme-default;
-
-          // Styles the tab's hover/focus state.
-          &:hover,
-          &:focus,
-          &.is-hover,
-          &.is-focus {
-            color: $theme-hover;
-          }
-
-          // Styles the tab's active state.
-          &:active,
-          &.is-active {
-            color: $theme-active;
-
-            // Displays indicator when active.
-            &::after {
-              @include tokens-icon('material-arrow_drop_down', $theme-active, $indicator-size, $pseudo: true);
-              @include linear-gradient(
-                to bottom,
-                transparent $indicator-start,
-                $theme-background $indicator-start,
-                $theme-background $indicator-stop,
-                transparent $indicator-stop
-              );
-            }
-
-          }
-
-          // Add left border to subsequent tabs.
-          + #{$selector}::before {
-            background-color: $theme-border;
-          }
-
-        }
-
-      }
-
-      &.-dropdown {
-        background-color: $theme-background;
-      }
-
-    }
-
-    // Build dark theme menu styles.
-    &.-dark {
-      $theme-background: map-deep-get($skin, 'theme.dark.background');
-      $theme-border: map-deep-get($skin, 'theme.dark.border');
-      $theme-default: map-deep-get($skin, 'theme.dark.foreground.default');
-      $theme-hover: map-deep-get($skin, 'theme.dark.foreground.hover');
-      $theme-active: map-deep-get($skin, 'theme.dark.foreground.active');
-
-      &:not(.-dropdown) {
-        background-color: $theme-background;
-
-        // Styles the horizontal rule under the menu.
-        &::after {
-          background-color: $theme-border;
-        }
-
-        // Styles tabs when inside a dark-themed menu.
-        #{$selector} {
-          color: $theme-default;
-
-          // Styles the tab's hover/focus state.
-          &:hover,
-          &:focus,
-          &.is-hover,
-          &.is-focus {
-            color: $theme-hover;
-          }
-
-          // Styles the tab's active state.
-          &:active,
-          &.is-active {
-            color: $theme-active;
-
-            // Displays indicator when active.
-            &::after {
-              @include tokens-icon('material-arrow_drop_down', $theme-active, $indicator-size, $pseudo: true);
-              @include linear-gradient(
-                to bottom,
-                transparent $indicator-start,
-                $theme-background $indicator-start,
-                $theme-background $indicator-stop,
-                transparent $indicator-stop
-              );
-            }
-
-          }
-
-          // Add left border to subsequent tabs.
-          + #{$selector}::before {
-            background-color: $theme-border;
-          }
-
-        }
-
-      }
-
-      &.-dropdown {
-        background-color: $theme-background;
-      }
-
+      height: $theme-border-thickness;
+      background-color: $theme-border-color;
     }
 
   }
@@ -263,22 +133,289 @@ $atoms-tab: (
 
     // Show the tab's active state when the switch is enabled.
     &:checked + #{$selector} {
-      color: $active;
-
-      // Displays indicator when active.
-      &::after {
-        @include tokens-icon('material-arrow_drop_down', $active, $indicator-size, $pseudo: true);
-        @include size( $indicator-size );
-      }
-
+      @include atoms-tab--state('active', $skin, $selector);
     }
 
     // Hide the tab's active state when the switch is disabled.
     &:not(:checked) + #{$selector} {
-      color: $default;
+      @include atoms-tab--state('normal', $skin, $selector);
+    }
 
+  }
+
+  // Apply theme-specific styles for the component.
+  @each $theme, $settings in $themes {
+
+    // Get theme-specific variables.
+    $theme-foreground: map-deep-get($settings, 'foreground.normal');
+    $theme-background: map-deep-get($settings, 'background');
+    $theme-border-color: map-deep-get($settings, 'border.color');
+    $theme-border-thickness: map-deep-get($settings, 'border.thickness');
+
+    // Apply theme-specific styles.
+    &-menu.-#{$theme} {
+      background-color: $theme-background;
+
+      // Modifies horizontal rule of the tab menu.
       &::after {
-        content: none;
+        height: $theme-border-thickness;
+        background-color: $theme-border-color;
+      }
+
+      // Override tab styles.
+      #{$selector} {
+        color: $theme-foreground;
+
+        // Modifies divider between to subsequent tabs.
+        & + &::before {
+          background-color: $theme-border-color;
+          width: $theme-border-thickness;
+        }
+
+      }
+
+    }
+
+  }
+
+}
+
+/// Defines the tab component state.
+///
+/// @since 1.0.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {string} state - The component's state to be styled
+/// @param {map} skin - The component's skin
+///
+/// @output The tab component's themeable properties
+@mixin atoms-tab--state( $state, $skin: $atoms-tab, $selector: true ) {
+
+  // For focus states, use the hover state styles.
+  $target: if($state == 'focus', 'hover', if($state == 'inactive', 'active', $state));
+
+  // Get theme-specific variables.
+  $theme-default: map-deep-get($skin, 'theme');
+  $themes: map-deep-get($skin, 'themes');
+
+  // Get skinable variables.
+  $indicator: map-deep-get($skin, 'indicator');
+
+  // Capture the selector class.
+  $selector-class: &;
+
+  @if( $selector == true and $state != 'normal' ) {
+
+    // Add theme-specific states.
+    @each $theme, $settings in $themes {
+
+      // Get theme-specific variables.
+      $theme-foreground: map-get($settings, 'foreground');
+      $theme-background: map-get($settings, 'background');
+
+      // Get state-specific variables based on theme-specific variables.
+      $state-foreground: map-deep-get($theme-foreground, $target);
+
+      // Build the targeted state selector.
+      $selector-state: unquote(if($theme == $theme-default, glue((
+        '&:#{$state}',
+        '&.is-#{$state}',
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
+      ), ', '), glue((
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &:#{$state}',
+        '#{$selector-class}-menu:not(.-dropdown).-#{$theme} &.is-#{$state}'
+      ), ', ')));
+
+      // Apply all state-specific styles for the given theme.
+      #{$selector-state} {
+        color: $state-foreground;
+
+        // Add an indicator when active.
+        @if( $state == 'active' ) {
+
+          // For smaller screens, add indicators at the left of the tab.
+          @include breakpoint-s-m {
+
+            &::before {
+              content: icon-url('material-arrow_right', $state-foreground, $indicator);
+            };
+
+          };
+
+          // For larger screens, add indicators below the tab.
+          @include breakpoint-l {
+
+            &::after {
+              content: icon-url('material-arrow_drop_down', $state-foreground, $indicator);
+            }
+
+          };
+
+        }
+
+        // Otherwise, remove indicators when not active.
+        @else {
+
+          // For smaller screens, remove indicators at the left of the tab.
+          @include breakpoint-s-m {
+
+            &::before {
+              content: none;
+            };
+
+          };
+
+          // For larger screens, remove indicators below the tab.
+          @include breakpoint-l {
+
+            &::after {
+              content: none;
+            }
+
+          };
+
+        }
+
+      }
+
+    }
+
+  }
+
+  @else {
+
+    // Add theme-specific states.
+    @each $theme, $settings in $themes {
+
+      // Get theme-specific variables.
+      $theme-foreground: map-get($settings, 'foreground');
+      $theme-background: map-get($settings, 'background');
+
+      // Get state-specific variables based on theme-specific variables.
+      $state-foreground: map-deep-get($theme-foreground, $target);
+
+      // Apply all state-specific styles for the given theme.
+      @if( $theme == $theme-default ) {
+        color: $state-foreground;
+
+        // Add an indicator when active.
+        @if( $state == 'active' ) {
+
+          // For smaller screens, add indicators at the left of the tab.
+          @include breakpoint-s-m {
+
+            &::before {
+              content: icon-url('material-arrow_right', $state-foreground, $indicator);
+            };
+
+          };
+
+          // For larger screens, add indicators below the tab.
+          @include breakpoint-l {
+
+            &::after {
+              content: icon-url('material-arrow_drop_down', $state-foreground, $indicator);
+              @include linear-gradient(
+                to bottom,
+                transparent 45%,
+                $theme-background 45%,
+                $theme-background 55%,
+                transparent 55%
+              );
+            }
+
+          };
+
+        }
+
+        // Otherwise, remove indicators when not active.
+        @else {
+
+          // For smaller screens, remove indicators at the left of the tab.
+          @include breakpoint-s-m {
+
+            &::before {
+              content: none;
+            };
+
+          };
+
+          // For larger screens, remove indicators below the tab.
+          @include breakpoint-l {
+
+            &::after {
+              content: none;
+            }
+
+          };
+
+        }
+
+      }
+
+      @if( $selector != false ) {
+
+        // Also, add state-specific styles within its themed menu.
+        @at-root #{$selector}-menu:not(.-dropdown).-#{$theme} & {
+          color: $state-foreground;
+
+          // Add an indicator when active.
+          @if( $state == 'active' ) {
+
+            // For smaller screens, add indicators at the left of the tab.
+            @include breakpoint-s-m {
+
+              &::before {
+                content: icon-url('material-arrow_right', $state-foreground, $indicator);
+              };
+
+            };
+
+            // For larger screens, add indicators below the tab.
+            @include breakpoint-l {
+
+              &::after {
+                content: icon-url('material-arrow_drop_down', $state-foreground, $indicator);
+                @include linear-gradient(
+                  to bottom,
+                  transparent 45%,
+                  $theme-background 45%,
+                  $theme-background 55%,
+                  transparent 55%
+                );
+              }
+
+            };
+
+          }
+
+          // Otherwise, remove indicators when not active.
+          @else {
+
+            // For smaller screens, remove indicators at the left of the tab.
+            @include breakpoint-s-m {
+
+              &::before {
+                content: none;
+              };
+
+            };
+
+            // For larger screens, remove indicators below the tab.
+            @include breakpoint-l {
+
+              &::after {
+                content: none;
+              }
+
+            };
+
+          }
+
+        }
+
       }
 
     }

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/tab/_structure.scss
@@ -2,6 +2,120 @@
 /// @group emory-libraries.patterns.atoms.tab
 ////
 
+/// Defines the tab component state structure.
+///
+/// @since 1.0.0
+///
+/// @requires {function} Brandy::map-deep-get <https://laurenhamel.github.io/brandy/docs/#brandy-maps-function-map-deep-get>
+///
+/// @param {string} state - The component's state to be structure
+///
+/// @output The tab component's themeable properties
+@mixin atoms-tab--state--structure( $state, $selector: true ) {
+
+  @if( $selector and $state != 'normal' ) {
+
+    @if( $state == 'active' ) {
+
+      &:#{$state},
+      &.is-#{$state} {
+
+        @include breakpoint-s-m {
+
+          &::before {
+            content: "";
+            display: block;
+            position: absolute;
+            left: 0;
+            @include absolute-center-within-container-y;
+          }
+
+        };
+
+        @include breakpoint-l {
+
+          &::after {
+            content: "";
+            display: block;
+            @include absolute( 100% null null 50% );
+            transform: translatey(-50%) translatex(-50%);
+            z-index: z('above');
+          }
+
+        };
+
+      }
+
+      @if( $selector != true ) {
+
+        @at-root #{$selector}-switch:checked + #{$selector} {
+
+          @include breakpoint-s-m {
+
+            &::before {
+              content: "";
+              display: block;
+              position: absolute;
+              left: 0;
+              @include absolute-center-within-container-y;
+            }
+
+          };
+
+          @include breakpoint-l {
+
+            &::after {
+              content: "";
+              display: block;
+              @include absolute( 100% null null 50% );
+              transform: translatey(-50%) translatex(-50%);
+              z-index: z('above');
+            }
+
+          };
+
+        }
+
+      }
+
+    }
+
+  }
+
+  @else {
+
+    @if( $state == 'active' ) {
+
+      @include breakpoint-s-m {
+
+        &::before {
+          content: "";
+          display: block;
+          position: absolute;
+          left: 0;
+          @include absolute-center-within-container-y;
+        }
+
+      };
+
+      @include breakpoint-l {
+
+        &::after {
+          content: "";
+          display: block;
+          @include absolute( 100% null null 50% );
+          transform: translatey(-50%) translatex(-50%);
+          z-index: z('above');
+        }
+
+      };
+
+    }
+
+  }
+
+}
+
 /// Defines the base structure of the tab component.
 ///
 /// @since 1.0.0
@@ -15,7 +129,7 @@
 %atoms-tab {
 
   // Capture class name.
-  $class: &;
+  $selector: &;
 
   // Defines the structure of the tab component.
   appearance: none;
@@ -24,50 +138,50 @@
   background: none !important;
   border: none !important;
   padding: ($rhythm-y / 4) ($rhythm-x * 2);
-  @include absolute-center-contents( true );
+  @include absolute-center-contents-y( true );
   cursor: pointer;
 
-  // Initiailzes a divider for each tab.
-  &::before {
-    content: "";
-    display: block;
-    position: absolute;
-    left: 0;
-  }
+  // Define tab structure on larger screens.
+  @include breakpoint-l {
+    @include absolute-center-contents( true );
 
-  // Initializes an indicator for each tab.
-  &::after {
-    content: "";
-    display: block;
-    @include absolute( 100% null null 50% );
-    transform: translatey(-50%) translatex(-50%);
-    z-index: z('above');
-  }
+    // Initiailzes a divider for each tab.
+    &::before {
+      content: "";
+      display: block;
+      position: absolute;
+      left: 0;
+    }
+
+  };
+
+  @include atoms-tab--state--structure('active', $selector);
 
   // Defines the structure of tab menus.
   &-menu {
     display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
     @include margin-y( $rhythm-y );
     padding-top: ($rhythm-y / 4);
     padding-bottom: ($rhythm-y / 2);
+    margin: 0;
 
-    // Defines structure of menu horizontal rule.
-    &::after {
-      content: "";
-      width: 100%;
-      position: absolute;
-      bottom: ($rhythm-y / 2);
-      left: 0;
-      right: 0;
-    }
+    // Modifies tab menu styles on larger screens.
+    @include breakpoint-l {
+      flex-direction: row;
 
-    // Defines structure of tabs within a menu.
-    #{$class} {
+      // Defines structure of menu horizontal rule.
+      &::after {
+        content: "";
+        width: 100%;
+        position: absolute;
+        bottom: ($rhythm-y / 2);
+        left: 0;
+        right: 0;
+      }
 
-      // Defines structure of tabs when active.
-      &.is-active { }
-
-    }
+    };
 
   }
 

--- a/src/scss/vends/emory-libraries/patterns/40-compounds/tab-menu/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/40-compounds/tab-menu/_structure.scss
@@ -16,7 +16,7 @@
   flex-wrap: nowrap;
 
   // Builds the tab menu default structure.
-  &:not(.-dropdown) {
+  &:not(.-dropdown):not(.-noscript) {
     display: none;
 
     // Only enable the tabbed view on larger screens.
@@ -50,6 +50,17 @@
     // Disable dropdown view on larger screens.
     @include breakpoint-l {
       display: none;
+    };
+
+  }
+
+  // Builds the tab menu noscript structure.
+  &.-noscript {
+    flex-direction: column;
+
+    // Allow tabs to use their native layout on larger screens.
+    @include breakpoint-l {
+      flex-direction: row;
     };
 
   }

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/_search-menu.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/_search-menu.scss
@@ -44,6 +44,9 @@
     &-back {
       @extend %organisms-search-menu-back;
     }
+    &-toggle {
+      @extend %organisms-search-menu-toggle;
+    }
 
     // Load skins.
     @include organisms-search-menu--theme( $skin );

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/intro-home/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/intro-home/_structure.scss
@@ -15,6 +15,7 @@
   grid-template-rows: minmax(180px, min-content) min-content 6fr repeat(2, min-content) 1fr;
   grid-template-columns: 1fr 2fr minmax(min-content, 800px) 2fr 1fr;
   background-size: cover;
+  background-position: center;
   height: 845px;
 
   &-search {

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/intro-home/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/intro-home/_structure.scss
@@ -12,7 +12,7 @@
 
   // Builds the intro-home structure.
   display: grid;
-  grid-template-rows: 180px min-content 6fr repeat(2, min-content) 1fr;
+  grid-template-rows: minmax(180px, min-content) min-content 6fr repeat(2, min-content) 1fr;
   grid-template-columns: 1fr 2fr minmax(min-content, 800px) 2fr 1fr;
   background-size: cover;
   height: 845px;

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_skin.scss
@@ -158,6 +158,10 @@ $organisms-search-menu: (
   // Configure search menu toggles to activate tabs and search boxes.
   &-toggle {
 
+    // Capture tab themes.
+    $atoms-tab-theme-default: map-deep-get($atoms-tab, 'theme');
+    $atoms-tab-themes: map-deep-get($atoms-tab, 'themes');
+
     // Hook toggles to tabs and search boxes.
     @for $n from 1 through $toggles-max {
 
@@ -167,10 +171,19 @@ $organisms-search-menu: (
         // Toggle tabs and search boxes when checked.
         &:checked {
 
-          @each $theme in map-keys(map-get($atoms-tab, 'themes')) {
+          @each $theme in map-keys($atoms-tab-themes) {
+
+            @if( $theme == $atoms-tab-theme-default ) {
+              ~ #{$selector}-tabs .tab-menu .tab:nth-of-type(#{$n}),
+              ~ #{$selector}-tabs noscript .tab-menu .tab:nth-of-type(#{$n}) {
+                @include atoms-tab--state--structure('active', false);
+                @include atoms-tab--state('active', $selector: false);
+              }
+            }
 
             // Hide the nth tab's active state.
-            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
+            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}),
+            ~ #{$selector}-tabs noscript .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
               @include atoms-tab--state--structure('active', false);
               @include atoms-tab--state('active', map-extend($atoms-tab, (
                 'theme': $theme
@@ -180,7 +193,8 @@ $organisms-search-menu: (
           }
 
           // Show the nth search box.
-          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}) {
+          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}),
+          ~ #{$selector}-search noscript .search .search-form:nth-of-type(#{$n}) {
             display: grid;
           }
 
@@ -189,10 +203,19 @@ $organisms-search-menu: (
         // Toggle tabs and search boxes when not checked.
         &:not(:checked) {
 
-          @each $theme in map-keys(map-get($atoms-tab, 'themes')) {
+          @each $theme in map-keys($atoms-tab-themes) {
+
+            @if( $theme == $atoms-tab-theme-default ) {
+              ~ #{$selector}-tabs .tab-menu .tab:nth-of-type(#{$n}),
+              ~ #{$selector}-tabs noscript .tab-menu .tab:nth-of-type(#{$n}) {
+                @include atoms-tab--state--structure('normal', false);
+                @include atoms-tab--state('normal', $selector: false);
+              }
+            }
 
             // Hide the nth tab's active state.
-            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
+            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}),
+            ~ #{$selector}-tabs noscript .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
               @include atoms-tab--state--structure('normal', false);
               @include atoms-tab--state('normal', map-extend($atoms-tab, (
                 'theme': $theme
@@ -202,7 +225,8 @@ $organisms-search-menu: (
           }
 
           // Hide the nth search box.
-          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}) {
+          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}),
+          ~ #{$selector}-search noscript .search .search-form:nth-of-type(#{$n}) {
             display: none;
           }
 

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_skin.scss
@@ -41,6 +41,10 @@ $organisms-search-menu: (
   'transition': (
     'duration': .5s,
     'timing': $transition-timing
+  ),
+
+  'toggles': (
+    'max': 10
   )
 
 );
@@ -74,6 +78,9 @@ $organisms-search-menu: (
   $theme-background: map-deep-get($themes, $theme + '.background');
   $theme-context: map-deep-get($themes, $theme + '.context');
   $theme-cancel: map-deep-get($themes, $theme + '.cancel');
+
+  // Get toggle-specific variables.
+  $toggles-max: map-deep-get($skin, 'toggles.max');
 
   // Defines the search-menu component's base styles.
   @include padding-x($padding-x);
@@ -144,6 +151,65 @@ $organisms-search-menu: (
     .tab-menu {
       background-color: transparent !important;
       transition: none !important;
+    }
+
+  }
+
+  // Configure search menu toggles to activate tabs and search boxes.
+  &-toggle {
+
+    // Hook toggles to tabs and search boxes.
+    @for $n from 1 through $toggles-max {
+
+      // Configure the nth toggle.
+      &:nth-of-type(#{$n}) {
+
+        // Toggle tabs and search boxes when checked.
+        &:checked {
+
+          @each $theme in map-keys(map-get($atoms-tab, 'themes')) {
+
+            // Hide the nth tab's active state.
+            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
+              @include atoms-tab--state--structure('active', false);
+              @include atoms-tab--state('active', map-extend($atoms-tab, (
+                'theme': $theme
+              )), false);
+            }
+
+          }
+
+          // Show the nth search box.
+          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}) {
+            display: grid;
+          }
+
+        }
+
+        // Toggle tabs and search boxes when not checked.
+        &:not(:checked) {
+
+          @each $theme in map-keys(map-get($atoms-tab, 'themes')) {
+
+            // Hide the nth tab's active state.
+            ~ #{$selector}-tabs .tab-menu.-#{$theme} .tab:nth-of-type(#{$n}) {
+              @include atoms-tab--state--structure('normal', false);
+              @include atoms-tab--state('normal', map-extend($atoms-tab, (
+                'theme': $theme
+              )), false);
+            }
+
+          }
+
+          // Hide the nth search box.
+          ~ #{$selector}-search .search .search-form:nth-of-type(#{$n}) {
+            display: none;
+          }
+
+        }
+
+      }
+
     }
 
   }

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_structure.scss
@@ -37,6 +37,7 @@
   // Builds the search menu context structure.
   &-context {
     grid-area: context;
+    @include margin-y($rhythm-y / 2);
 
     // Always hide the context on larger screens.
     @include breakpoint-l {
@@ -51,10 +52,12 @@
   }
 
   // Builds the search menu search structure.
-  &-search {
+  &-search,
+  &-search noscript {
     grid-area: search;
     display: flex;
     align-items: center;
+    width: 100%;
 
     // Always force search to be full-width of its container.
     .search {
@@ -96,7 +99,7 @@
 
     // Hide the search menu back container for home variants.
     @include when-descendant-of('#{$selector}.-home') {
-      display: none;
+      display: none !important;
     };
 
   }

--- a/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_structure.scss
+++ b/src/scss/vends/emory-libraries/patterns/50-organisms/search-menu/_structure.scss
@@ -10,6 +10,9 @@
   // Capture selector.
   $selector: &;
 
+  // Set a maximum number of toggles that can be configured.
+  $max-toggles: 10;
+
   // Builds the search-menu structure.
   display: grid;
   grid-template-areas: "context"
@@ -96,6 +99,11 @@
       display: none;
     };
 
+  }
+
+  // Builds the search menu toggle structure.
+  &-toggle {
+    display: none;
   }
 
 }


### PR DESCRIPTION
This adds in the `noscript` version of the `organisms-search-menu` pattern, which required modifying `atoms-tab`, `atoms-search`, and `compounds-tab-menu`. Related #280.