### PR TITLE
Fix for events not loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Pattern-Library",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9795,7 +9795,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -372,6 +372,11 @@ const EUL = {
                   // Get the filters.
                   const filters = utils.getFilters(placeholder);
 
+                  //If value is `undefined`, set it to empty string to prevent error with `utils.applyFilters()`.
+                  if(value === undefined){
+                    value = '';
+                  }
+
                   // Apply the filters to the value.
                   value = utils.applyFilters(value, filters);
 


### PR DESCRIPTION
Prevents `TypeError` that was stopping the event data from rendering by changing the value of the `value` variable from `undefined` to `''` before being passed into `utils.applyFilters()'.