### PR TITLE
Fixes January events not loading

### DIFF
--- a/src/_patterns/60-templates/events/calendar.js
+++ b/src/_patterns/60-templates/events/calendar.js
@@ -192,7 +192,7 @@ Components.register('calendar', {
         // If it's 0, change it to a string so that _.compact() keeps it or else it will drop.
         event.m = _.compact(_.uniq([
           start.moment.isValid() ? start.moment.month().toString() : null,
-          end.moment.isValid() ? end.moment.month().toString() : null,
+          end.moment.isValid() ? end.moment.month().toString() : null
         ]))[0];
         event.year = _.compact(_.uniq([
           start.moment.isValid() ? start.moment.year() : null,

--- a/src/_patterns/60-templates/events/calendar.js
+++ b/src/_patterns/60-templates/events/calendar.js
@@ -189,9 +189,10 @@ Components.register('calendar', {
         event.year = -1;
 
         // Determine the month and year that the event falls in.
+        // If it's 0, change it to a string so that _.compact() keeps it or else it will drop.
         event.m = _.compact(_.uniq([
-          start.moment.isValid() ? start.moment.month() : null,
-          end.moment.isValid() ? end.moment.month() : null
+          start.moment.isValid() ? start.moment.month().toString() : null,
+          end.moment.isValid() ? end.moment.month().toString() : null,
         ]))[0];
         event.year = _.compact(_.uniq([
           start.moment.isValid() ? start.moment.year() : null,


### PR DESCRIPTION
January event were not loading due to the use of the `_.compact()` method in lodash stripping out the number `0` as a "falsy" value. Switching the values to strings keeps them in the array.