### PR TITLE
Clare caption test

### DIFF
--- a/patternlab-config.json
+++ b/patternlab-config.json
@@ -82,9 +82,18 @@
   "ishMinimum": 240,
   "ishMaximum": 2600,
   "ishViewportRange": {
-    "s": [240, 500],
-    "m": [500, 800],
-    "l": [800, 2600]
+    "s": [
+      240,
+      500
+    ],
+    "m": [
+      500,
+      800
+    ],
+    "l": [
+      800,
+      2600
+    ]
   },
   "patternStateCascade": [
     "specification",

--- a/src/_patterns/30-molecules/media/figure.hbs
+++ b/src/_patterns/30-molecules/media/figure.hbs
@@ -3,7 +3,7 @@
   {{#if (or caption credit)}}
     <figcaption class="figure-caption">
       {{#if credit}}
-        {{assign 'credit' (combine 'Photo by ' credit '.')}}
+        {{assign 'credit' (combine ' Photo by ' credit '.')}}
       {{/if}}
       {{> tokens-text type='caption' text=(combine caption credit)}}
     </figcaption>

--- a/src/_patterns/30-molecules/media/figure.json
+++ b/src/_patterns/30-molecules/media/figure.json
@@ -2,6 +2,6 @@
   "image": {
     "src": "//source.unsplash.com/sUTZ280MFpc/1000x600",
     "alt": "A mask from South Africa."
-  },
-  "caption": "Recently retired Rose Library curator Randall K. Burkett will share stories of how he discovered and brought many of the African American collections to the Rose Library in a Creativity Conversation with former Rose Library director Rosemary Magee."
+    },
+  "caption": "Recently retired Rose Library curator Randall K. Burkett will share stories of how he discovered and brought many of the African American collections to the Rose Library in a Creativity Conversation with former Rose Library director Rosemary Magee.",
 }

--- a/src/_patterns/60-templates/exhibitions/exhibition.hbs
+++ b/src/_patterns/60-templates/exhibitions/exhibition.hbs
@@ -31,7 +31,7 @@
       {{#content 'section-main-sidebar'}}
 
         {{! Display the image if available. }}
-        {{#if image}}{{> molecules-figure}}{{/if}}
+        {{#if image}}{{> molecules-figure caption=image.caption credit=image.credit}}{{/if}}
 
         {{! Display the date. }}
         <span class="exhibition-page-main-date">{{date.display}}</span>

--- a/src/_patterns/60-templates/exhibitions/exhibition.json
+++ b/src/_patterns/60-templates/exhibitions/exhibition.json
@@ -15,8 +15,8 @@
   },
   "image": {
     "src": "//source.unsplash.com/random",
-    "caption": "it is not the critic who counts",
-    "credit": "... but the man in the arena"
+    "caption": "It is not the critic who counts.",
+    "credit": "the man in the arena"
   },
   "quote": "The Beat Generation moves us beyond a literary movement to a significant historical moment, one that still speaks to us.",
   "details": "This exhibition, curated by Clayton McGahee and Matt Miller, provides an Emory perspective of nursing from past to present, highlighting those who have shaped the program.\nBeginning with the Wesley Memorial Hospital Training School for Nurses in 1905, the school worked in partnership with the hospital, requiring that nurses reside in dormitories and maintain a strict dress code at all times. In the years that followed, Emory advanced from a small program with a graduating class of 10, to what is now recognized as a leading nursing school in the United States.\nAs the Ebola virus outbreak in 2014 proved, Emory nurses play an integral part in collaborating and providing medical care to the global community. From Atlanta to the most remote areas around the globe, Emory nurses are at the frontlines of global health. The World Health Organization claims that nurses provide 90 percent of all health care services worldwide, indicating that nurses are the modern-day heroes of global health.",

--- a/src/_patterns/60-templates/exhibitions/exhibition.json
+++ b/src/_patterns/60-templates/exhibitions/exhibition.json
@@ -15,8 +15,8 @@
   },
   "image": {
     "src": "//source.unsplash.com/random",
-    "caption": null,
-    "credit": ""
+    "caption": "it is not the critic who counts",
+    "credit": "... but the man in the arena"
   },
   "quote": "The Beat Generation moves us beyond a literary movement to a significant historical moment, one that still speaks to us.",
   "details": "This exhibition, curated by Clayton McGahee and Matt Miller, provides an Emory perspective of nursing from past to present, highlighting those who have shaped the program.\nBeginning with the Wesley Memorial Hospital Training School for Nurses in 1905, the school worked in partnership with the hospital, requiring that nurses reside in dormitories and maintain a strict dress code at all times. In the years that followed, Emory advanced from a small program with a graduating class of 10, to what is now recognized as a leading nursing school in the United States.\nAs the Ebola virus outbreak in 2014 proved, Emory nurses play an integral part in collaborating and providing medical care to the global community. From Atlanta to the most remote areas around the globe, Emory nurses are at the frontlines of global health. The World Health Organization claims that nurses provide 90 percent of all health care services worldwide, indicating that nurses are the modern-day heroes of global health.",


### PR DESCRIPTION
The differences in the patternlab-config.json must just be because the way my vscode formatted it, so it can be discarded. And the space in the figure.json was from when I moved the caption inside the object and it can be discarded, too. 