### PR TITLE
Fixes scrollbar appearing in About/Access Links as they appear

### DIFF
--- a/src/_patterns/20-atoms/buttons/21-subnav-button~main.css
+++ b/src/_patterns/20-atoms/buttons/21-subnav-button~main.css
@@ -353,8 +353,6 @@
 }
 .subnav-button.-resource .subnav-button-options {
   --max: 300px;
-  -webkit-transition: all 0.25s ease;
-  transition: all 0.25s ease;
   -webkit-box-shadow: inset 2px 2px 3px rgba(9, 28, 68, 0.1);
           box-shadow: inset 2px 2px 3px rgba(9, 28, 68, 0.1);
   color: inherit;

--- a/src/scss/vends/emory-libraries/patterns/20-atoms/subnav-button/_skin.scss
+++ b/src/scss/vends/emory-libraries/patterns/20-atoms/subnav-button/_skin.scss
@@ -401,7 +401,7 @@ $atoms-subnav-button: (
     #{$selector}-options {
       --max: 300px;
 
-      transition: all $duration $timing;
+      //transition: all $duration $timing;
       @if( is-null($menu-shadow) == false and $menu-shadow != false ) {
         box-shadow: $menu-shadow;
       }


### PR DESCRIPTION
This removes the transition animation from the about/access links to render them as static rather than sliding out.

Fixes [#268 in Web Redesign](https://app.zenhub.com/workspaces/website-redesign-5be9f5af4b5806bc2bf3ddda/issues/emory-libraries/web-redesign/268).