### PR TITLE
Add Lux to main search options

### DIFF
--- a/src/_patterns/50-organisms/intros/intro~home.json
+++ b/src/_patterns/50-organisms/intros/intro~home.json
@@ -27,6 +27,10 @@
         "value": "ejournals"
       },
       {
+        "label": "Digital Collections",
+        "value": "digital-collections"
+      },
+      {
         "label": "Research & Course Guides",
         "value": "research-guides"
       },
@@ -58,6 +62,12 @@
         "placeholder": "Search Journal Titles",
         "id": "ejournals",
         "src": "http://emory-primoprod.hosted.exlibrisgroup.com/primo_library/libweb/action/dlSearch.do?institution=01EMORY&vid=discovere&loc=local%2Cscope%3A%28AZ01EMORY%29&fn=goAlmaAz&almaAzSearch=true&vl(freeText0)=:query&libsearch=woodruff"
+      },
+      {
+        "label": "Digital Collections",
+        "placeholder": "Search Emory Digital Collections",
+        "id": "digital-collections",
+        "src": "http://digital.library.emory.edu/?utf8=%E2%9C%93&search_field=common_fields&q=:query"
       },
       {
         "label": "Research & Course Guides",


### PR DESCRIPTION
- Users can now select "Digital Collections" in the main search bar and search against materials in Lux

**User enters a search on Digital Collections:**
<img width="1238" alt="Screen Shot 2020-07-22 at 1 15 51 PM" src="https://user-images.githubusercontent.com/46227821/88207475-d81b3100-cc1d-11ea-8548-7edcd739a43c.png">


**User is taken to Lux search page:**
<img width="1164" alt="Screen Shot 2020-07-22 at 1 16 12 PM" src="https://user-images.githubusercontent.com/46227821/88207486-dea9a880-cc1d-11ea-8d5b-c152eaada7e9.png">

