### PR TITLE
Fix order of events in calendar

### DIFF
--- a/src/_patterns/60-templates/events/calendar.js
+++ b/src/_patterns/60-templates/events/calendar.js
@@ -189,11 +189,12 @@ Components.register('calendar', {
         event.year = -1;
 
         // Determine the month and year that the event falls in.
-        // If it's 0, change it to a string so that _.compact() keeps it or else it will drop.
-        event.m = _.compact(_.uniq([
-          start.moment.isValid() ? start.moment.month().toString() : null,
-          end.moment.isValid() ? end.moment.month().toString() : null
-        ]))[0];
+        // Because moment.js indexes month values starting at 0, use _.pickBy() and _.isNumber
+        // instead of _.compact(), which would remove all 0 values.
+        event.m = _.pickBy(_.uniq([
+          start.moment.isValid() ? start.moment.month() : null,
+          end.moment.isValid() ? end.moment.month() : null
+        ]), _.isNumber)[0];
         event.year = _.compact(_.uniq([
           start.moment.isValid() ? start.moment.year() : null,
           end.moment.isValid() ? end.moment.year() : null


### PR DESCRIPTION
Events in November and December were displaying out of order in the calendar because (1) `moment` indexes month values starting at 0 (meaning November is 10 and December is 11), (2) the Pattern Library was saving month values as string values in order to get around a `lodash` quirk, and (3) months were being compared as strings and not numbers (so "10" comes before "8"). Months are now saved as number values so that they are grouped and compared correctly.